### PR TITLE
remove unused map labels (temp and humidity)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -164,10 +164,6 @@
 				<option value="PM10"> PM10</option>
 				<option value="PM25"> PM2.5</option>
 				<option value="Official_AQI_US"> Official AQI US</option>
-				<!-- <option value="Temperature"> Temperature</option> -->
-				<!-- <option value="Humidity"> rel. Humidity</option> -->
-				<!--<option value="Pressure"> Pressure</option>
-				<option value="Noise"> Noise</option>-->
 			</select>
 		</div>
 	</div>

--- a/src/index.html
+++ b/src/index.html
@@ -164,8 +164,8 @@
 				<option value="PM10"> PM10</option>
 				<option value="PM25"> PM2.5</option>
 				<option value="Official_AQI_US"> Official AQI US</option>
-				<option value="Temperature"> Temperature</option>
-				<option value="Humidity"> rel. Humidity</option>
+				<!-- <option value="Temperature"> Temperature</option> -->
+				<!-- <option value="Humidity"> rel. Humidity</option> -->
 				<!--<option value="Pressure"> Pressure</option>
 				<option value="Noise"> Noise</option>-->
 			</select>


### PR DESCRIPTION
## Description
Remove temp and humidity as not all sources have this.

## Type of change

- [x] Fix


## Desktop Screenshots
![image](https://user-images.githubusercontent.com/23483005/100422281-ea9cef80-3081-11eb-8484-57b4a5b4d726.png)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation



